### PR TITLE
Fix torch.load compatibility for PyTorch 2.6+ and correct typos

### DIFF
--- a/gammagl/data/dataset.py
+++ b/gammagl/data/dataset.py
@@ -331,7 +331,7 @@ class Dataset(Dataset):
                 f"The `pre_transform` argument differs from the one used in "
                 f"the pre-processed version of this dataset. If you want to "
                 f"make use of another pre-processing technique, make sure to "
-                f"sure to delete '{self.processed_dir}' first"
+                f"delete '{self.processed_dir}' first"
                 f"`force_reload=True` explicitly to reload the dataset.")
 
         f = osp.join(self.processed_dir, tlx.BACKEND + '_pre_filter.pt')

--- a/gammagl/data/dataset.py
+++ b/gammagl/data/dataset.py
@@ -339,7 +339,7 @@ class Dataset(Dataset):
             warnings.warn(
                 "The `pre_filter` argument differs from the one used in the "
                 "pre-processed version of this dataset. If you want to make "
-                "use of another pre-fitering technique, make sure to delete "
+                "use of another pre-filtering technique, make sure to delete "
                 "'{self.processed_dir}' first"
                 "`force_reload=True` explicitly to reload the dataset.")
 

--- a/gammagl/data/dataset.py
+++ b/gammagl/data/dataset.py
@@ -154,12 +154,23 @@ class Dataset(Dataset):
             obj[0].tensor()
         elif tlx.BACKEND == 'torch':
             import torch
+            import inspect
+            
+            # Device detection logic
             id = torch.tensor(1).get_device()
             if id != -1:
                 device = 'cuda:' + str(id)
             else:
                 device = 'cpu'
-            obj = torch.load(file_name, map_location=device)
+            
+            # Check if current torch.load supports 'weights_only' argument (PyTorch 2.4+)
+            sig = inspect.signature(torch.load)
+            if 'weights_only' in sig.parameters:
+                # Explicitly set weights_only=False to allow loading complex objects (like Graph)
+                obj = torch.load(file_name, map_location=device, weights_only=False)
+            else:
+                # Fallback for older PyTorch versions without this argument
+                obj = torch.load(file_name, map_location=device)
         else:
             with open(file_name, 'rb') as f:
                 obj = pickle.load(f)


### PR DESCRIPTION
This PR resolves an `UnpicklingError` when running on PyTorch 2.6+ (where `weights_only=True` is the default).

Changes included:
1.  **PyTorch Compatibility**: Added an inspection check for `weights_only` in `load_data`. If supported, it explicitly sets `weights_only=False` to allow loading custom Graph objects.
2.  **Typos Fixed**:
    * Removed repeated "sure to sure to" in warning message.
    * Corrected spelling of "pre-fitering" to "pre-filtering".

Tested locally and verified that the dataset loads correctly.