### PR TITLE
[Doc] Fix broken visitor badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/BUPT-GAMMA/GammaGL)
 [![Documentation Status](https://readthedocs.org/projects/gammagl/badge/?version=latest)](https://gammagl.readthedocs.io/en/latest/?badge=latest)
 ![GitHub](https://img.shields.io/github/license/BUPT-GAMMA/GammaGL)
-![visitors](https://visitor-badge.glitch.me/badge?page_id=BUPT-GAMMA.GammaGL)
+![visitors](https://visitor-badge.laobi.icu/badge?page_id=BUPT-GAMMA.GammaGL)
 ![GitHub all releases](https://img.shields.io/github/downloads/BUPT-GAMMA/GammaGL/total)
 ![Total lines](https://img.shields.io/tokei/lines/github/BUPT-GAMMA/GammaGL?color=red)
 


### PR DESCRIPTION
## Description
The visitor badge image in `README.md` was failing to load (returning a 410 error) because the upstream service `glitch.me` is down.
This PR replaces the broken link with the working alternative `visitor-badge.laobi.icu` to restore the badge functionality.

## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR

## Changes
- Replaced defunct `visitor-badge.glitch.me` link with `visitor-badge.laobi.icu` in `README.md`.