### PR TITLE
feat(nodeid): add NodeID model and two-stage node classification example

### DIFF
--- a/examples/nodeid/nodeid_id_mlp.py
+++ b/examples/nodeid/nodeid_id_mlp.py
@@ -1,0 +1,242 @@
+# !/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import os
+import argparse
+import random
+import numpy as np
+import sys
+from pathlib import Path
+import tensorlayerx as tlx
+from tensorlayerx.model import TrainOneStep, WithLoss
+
+os.environ.setdefault('TL_BACKEND', 'torch')
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from gammagl.datasets import Planetoid
+from gammagl.utils import mask_to_index
+from gammagl.models import MLP
+
+
+def fix_seed(seed=42):
+    random.seed(seed)
+    np.random.seed(seed)
+    if os.environ.get('TL_BACKEND', 'torch').lower() == 'torch':
+        try:
+            import torch
+            torch.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(seed)
+                torch.cuda.manual_seed_all(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+            try:
+                torch.use_deterministic_algorithms(True)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+
+def random_split_indices(num_nodes, train_prop=0.6, valid_prop=0.2, split_seed=None):
+    if split_seed is None:
+        perm = np.random.permutation(num_nodes)
+    else:
+        rng = np.random.RandomState(split_seed)
+        perm = rng.permutation(num_nodes)
+    train_num = int(train_prop * num_nodes)
+    valid_num = int(valid_prop * num_nodes)
+    train_idx = tlx.convert_to_tensor(perm[:train_num], dtype=tlx.int64)
+    valid_idx = tlx.convert_to_tensor(perm[train_num:train_num + valid_num], dtype=tlx.int64)
+    test_idx = tlx.convert_to_tensor(perm[train_num + valid_num:], dtype=tlx.int64)
+    return {
+        'train': train_idx,
+        'valid': valid_idx,
+        'test': test_idx,
+    }
+
+
+def calculate_acc(logits, y, metrics):
+    metrics.update(logits, y)
+    rst = metrics.result()
+    metrics.reset()
+    return rst
+
+
+class SemiSpvzLoss(WithLoss):
+    def __init__(self, net, loss_fn):
+        super(SemiSpvzLoss, self).__init__(backbone=net, loss_fn=loss_fn)
+
+    def forward(self, data, y):
+        logits = self.backbone_network(data['x'])
+        train_logits = tlx.gather(logits, data['train_idx'])
+        train_y = tlx.gather(data['y'], data['train_idx'])
+        loss = self._loss_fn(train_logits, train_y)
+        return loss
+
+
+def evaluate(model, data, metrics):
+    model.set_eval()
+    logits = model(data['x'])
+
+    train_logits = tlx.gather(logits, data['train_idx'])
+    train_y = tlx.gather(data['y'], data['train_idx'])
+    valid_logits = tlx.gather(logits, data['valid_idx'])
+    valid_y = tlx.gather(data['y'], data['valid_idx'])
+    test_logits = tlx.gather(logits, data['test_idx'])
+    test_y = tlx.gather(data['y'], data['test_idx'])
+
+    result = {
+        'train_acc': calculate_acc(train_logits, train_y, metrics),
+        'valid_acc': calculate_acc(valid_logits, valid_y, metrics),
+        'test_acc': calculate_acc(test_logits, test_y, metrics),
+    }
+    return result
+
+
+def load_semantic_id(path):
+    data = np.load(path)
+    if 'arr_0' in data:
+        arr = data['arr_0']
+    else:
+        first_key = list(data.keys())[0]
+        arr = data[first_key]
+    return tlx.convert_to_tensor(arr, dtype=tlx.float32)
+
+
+def main(args):
+    split_seed = args.seed if args.split_seed < 0 else args.split_seed
+    train_seed = args.seed if args.train_seed < 0 else args.train_seed
+
+    fix_seed(train_seed)
+
+    if str.lower(args.dataset) not in ['cora', 'citeseer', 'pubmed']:
+        raise ValueError(f'Unknown dataset: {args.dataset}')
+
+    dataset = Planetoid(args.dataset_path, args.dataset)
+    graph = dataset[0]
+
+    if args.rand_split:
+        split_idx = random_split_indices(
+            graph.num_nodes,
+            train_prop=args.train_prop,
+            valid_prop=args.valid_prop,
+            split_seed=split_seed,
+        )
+    else:
+        split_idx = {
+            'train': mask_to_index(graph.train_mask),
+            'valid': mask_to_index(graph.val_mask),
+            'test': mask_to_index(graph.test_mask),
+        }
+
+    semantic_path = args.semantic_id_path or f'semantic_ID_{args.dataset}.npz'
+    semantic_id = load_semantic_id(semantic_path)
+    semantic_shape = tlx.get_tensor_shape(semantic_id)
+    if semantic_shape[0] != graph.num_nodes:
+        raise ValueError(
+            f'semantic id node count mismatch: got {semantic_shape[0]}, expected {graph.num_nodes}'
+        )
+
+    feats = semantic_id
+    y = graph.y
+    if len(tlx.get_tensor_shape(y)) > 1:
+        y = tlx.squeeze(y, axis=-1)
+
+    input_dim = semantic_shape[1] if args.num_id <= 0 else args.num_id
+    if input_dim != semantic_shape[1]:
+        raise ValueError(f'num_id={args.num_id} does not match semantic dim={semantic_shape[1]}')
+
+    if args.norm_type == 'layer':
+        raise ValueError('GammaGL MLP does not support layer norm in this script, please use --norm_type none or batch')
+
+    norm = tlx.nn.BatchNorm1d(gamma_init='ones') if args.norm_type == 'batch' else None
+    model = MLP(
+        in_channels=input_dim,
+        hidden_channels=args.hidden_channels,
+        out_channels=dataset.num_classes,
+        num_layers=args.num_layers,
+        dropout=args.dropout,
+        norm=norm,
+        plain_last=True,
+    )
+
+    optimizer = tlx.optimizers.Adam(lr=args.lr, weight_decay=args.l2_coef)
+    metrics = tlx.metrics.Accuracy()
+    train_weights = model.trainable_weights
+
+    loss_func = SemiSpvzLoss(model, tlx.losses.softmax_cross_entropy_with_logits)
+    train_one_step = TrainOneStep(loss_func, optimizer, train_weights)
+
+    data = {
+        'x': feats,
+        'y': y,
+        'train_idx': split_idx['train'],
+        'valid_idx': split_idx['valid'],
+        'test_idx': split_idx['test'],
+    }
+
+    best_valid = float('-inf')
+    best_test = float('-inf')
+
+    print(f'dataset={args.dataset}, stage=ID-MLP, semantic_id={semantic_path}')
+
+    for epoch in range(args.n_epoch):
+        model.set_train()
+        train_loss = train_one_step(data, y)
+
+        result = evaluate(model, data, metrics)
+        if result['valid_acc'] > best_valid:
+            best_valid = result['valid_acc']
+            best_test = result['test_acc']
+
+        if epoch % args.display_step == 0:
+            print(
+                f"Epoch [{epoch + 1:0>3d}]  "
+                f"train loss: {train_loss.item():.4f}  "
+                f"train acc: {result['train_acc'] * 100:.2f}%  "
+                f"val acc: {result['valid_acc'] * 100:.2f}%  "
+                f"test acc: {result['test_acc'] * 100:.2f}%  "
+                f"best val: {best_valid * 100:.2f}%  "
+                f"best test: {best_test * 100:.2f}%"
+            )
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='NodeID Stage-2 ID-MLP in GammaGL')
+    parser.add_argument('--dataset', type=str, default='cora')
+    parser.add_argument('--dataset_path', type=str, default='')
+    parser.add_argument('--gpu', type=int, default=0)
+    parser.add_argument('--seed', type=int, default=42)
+    parser.add_argument('--split_seed', type=int, default=-1)
+    parser.add_argument('--train_seed', type=int, default=-1)
+
+    parser.add_argument('--rand_split', action='store_true')
+    parser.add_argument('--train_prop', type=float, default=0.6)
+    parser.add_argument('--valid_prop', type=float, default=0.2)
+
+    parser.add_argument('--semantic_id_path', type=str, default='')
+    parser.add_argument('--num_id', type=int, default=-1)
+
+    parser.add_argument('--n_epoch', type=int, default=1000)
+    parser.add_argument('--display_step', type=int, default=50)
+    parser.add_argument('--lr', type=float, default=0.001)
+    parser.add_argument('--l2_coef', type=float, default=5e-4)
+
+    parser.add_argument('--num_layers', type=int, default=3)
+    parser.add_argument('--hidden_channels', type=int, default=256)
+    parser.add_argument('--dropout', type=float, default=0.0)
+    parser.add_argument('--norm_type', type=str, default='none', choices=['none', 'batch', 'layer'])
+
+    args = parser.parse_args()
+
+    if args.gpu >= 0:
+        tlx.set_device('GPU', args.gpu)
+    else:
+        tlx.set_device('CPU')
+
+    main(args)

--- a/examples/nodeid/nodeid_trainer.py
+++ b/examples/nodeid/nodeid_trainer.py
@@ -1,0 +1,255 @@
+# !/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import os
+import argparse
+import random
+import numpy as np
+import sys
+from pathlib import Path
+
+os.environ.setdefault('TL_BACKEND', 'torch')
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import tensorlayerx as tlx
+from tensorlayerx.model import TrainOneStep, WithLoss
+
+from gammagl.datasets import Planetoid
+from gammagl.utils import add_self_loops, remove_self_loops, to_undirected, mask_to_index
+from gammagl.models import NodeIDGNN
+
+
+def fix_seed(seed=42):
+    random.seed(seed)
+    np.random.seed(seed)
+    if os.environ.get('TL_BACKEND', 'torch').lower() == 'torch':
+        try:
+            import torch
+            torch.manual_seed(seed)
+            if torch.cuda.is_available():
+                torch.cuda.manual_seed(seed)
+                torch.cuda.manual_seed_all(seed)
+            torch.backends.cudnn.deterministic = True
+            torch.backends.cudnn.benchmark = False
+            try:
+                torch.use_deterministic_algorithms(True)
+            except Exception:
+                pass
+        except Exception:
+            pass
+
+
+def random_split_indices(num_nodes, train_prop=0.6, valid_prop=0.2, split_seed=None):
+    if split_seed is None:
+        perm = np.random.permutation(num_nodes)
+    else:
+        rng = np.random.RandomState(split_seed)
+        perm = rng.permutation(num_nodes)
+    train_num = int(train_prop * num_nodes)
+    valid_num = int(valid_prop * num_nodes)
+    train_idx = tlx.convert_to_tensor(perm[:train_num], dtype=tlx.int64)
+    valid_idx = tlx.convert_to_tensor(perm[train_num:train_num + valid_num], dtype=tlx.int64)
+    test_idx = tlx.convert_to_tensor(perm[train_num + valid_num:], dtype=tlx.int64)
+    return {
+        'train': train_idx,
+        'valid': valid_idx,
+        'test': test_idx,
+    }
+
+
+def calculate_acc(logits, y, metrics):
+    metrics.update(logits, y)
+    rst = metrics.result()
+    metrics.reset()
+    return rst
+
+
+class SemiSpvzLoss(WithLoss):
+    def __init__(self, net, loss_fn, commit_weight):
+        super(SemiSpvzLoss, self).__init__(backbone=net, loss_fn=loss_fn)
+        self.commit_weight = commit_weight
+
+    def forward(self, data, y):
+        logits, commit_loss, _, _ = self.backbone_network(data['x'], data['edge_index'])
+        train_logits = tlx.gather(logits, data['train_idx'])
+        train_y = tlx.gather(data['y'], data['train_idx'])
+        loss = self._loss_fn(train_logits, train_y) + self.commit_weight * commit_loss
+        return loss
+
+
+def evaluate(model, data, metrics):
+    model.set_eval()
+    logits, _, _, _ = model(data['x'], data['edge_index'])
+
+    train_logits = tlx.gather(logits, data['train_idx'])
+    train_y = tlx.gather(data['y'], data['train_idx'])
+    valid_logits = tlx.gather(logits, data['valid_idx'])
+    valid_y = tlx.gather(data['y'], data['valid_idx'])
+    test_logits = tlx.gather(logits, data['test_idx'])
+    test_y = tlx.gather(data['y'], data['test_idx'])
+
+    return {
+        'train_acc': calculate_acc(train_logits, train_y, metrics),
+        'valid_acc': calculate_acc(valid_logits, valid_y, metrics),
+        'test_acc': calculate_acc(test_logits, test_y, metrics),
+    }
+
+
+def save_semantic_id(model, x, edge_index, output_path):
+    model.set_eval()
+    _, _, id_list_concat, _ = model(x, edge_index)
+    np.savez(output_path, tlx.convert_to_numpy(id_list_concat))
+    print(f'saved semantic id to {output_path}')
+
+
+def extract_semantic_id(model, x, edge_index):
+    model.set_eval()
+    _, _, id_list_concat, _ = model(x, edge_index)
+    return tlx.convert_to_numpy(id_list_concat)
+
+
+def main(args):
+    split_seed = args.seed if args.split_seed < 0 else args.split_seed
+    train_seed = args.seed if args.train_seed < 0 else args.train_seed
+
+    fix_seed(train_seed)
+
+    if str.lower(args.dataset) not in ['cora', 'citeseer', 'pubmed']:
+        raise ValueError('Unknown dataset: {}'.format(args.dataset))
+
+    dataset = Planetoid(args.dataset_path, args.dataset)
+    graph = dataset[0]
+
+    edge_index = to_undirected(graph.edge_index)
+    edge_index, _ = remove_self_loops(edge_index)
+    edge_index, _ = add_self_loops(edge_index, num_nodes=graph.num_nodes, n_loops=1)
+
+    if args.rand_split:
+        split_idx = random_split_indices(
+            graph.num_nodes,
+            train_prop=args.train_prop,
+            valid_prop=args.valid_prop,
+            split_seed=split_seed,
+        )
+    else:
+        split_idx = {
+            'train': mask_to_index(graph.train_mask),
+            'valid': mask_to_index(graph.val_mask),
+            'test': mask_to_index(graph.test_mask),
+        }
+
+    y = graph.y
+    if len(tlx.get_tensor_shape(y)) > 1:
+        y = tlx.squeeze(y, axis=-1)
+
+    model = NodeIDGNN(
+        in_channels=dataset.num_node_features,
+        hidden_channels=args.hidden_channels,
+        out_channels=dataset.num_classes,
+        local_layers=args.local_layers,
+        in_dropout=args.in_dropout,
+        dropout=args.dropout,
+        heads=args.num_heads,
+        pre_ln=args.pre_ln,
+        kmeans=args.kmeans,
+        num_codes=args.num_codes,
+        gnn=args.method,
+    )
+
+    optimizer = tlx.optimizers.Adam(lr=args.lr, weight_decay=args.l2_coef)
+    metrics = tlx.metrics.Accuracy()
+    train_weights = model.trainable_weights
+
+    loss_func = SemiSpvzLoss(model, tlx.losses.softmax_cross_entropy_with_logits, args.commit_weight)
+    train_one_step = TrainOneStep(loss_func, optimizer, train_weights)
+
+    data = {
+        'x': graph.x,
+        'y': y,
+        'edge_index': edge_index,
+        'train_idx': split_idx['train'],
+        'valid_idx': split_idx['valid'],
+        'test_idx': split_idx['test'],
+    }
+
+    best_valid = 0.0
+    best_test = 0.0
+    best_semantic_id = None
+
+    print(f'dataset={args.dataset}, method={args.method}')
+
+    for epoch in range(args.n_epoch):
+        model.set_train()
+        train_loss = train_one_step(data, y)
+
+        result = evaluate(model, data, metrics)
+
+        if result['valid_acc'] > best_valid:
+            best_valid = result['valid_acc']
+            best_test = result['test_acc']
+            if args.save_semantic_id:
+                best_semantic_id = extract_semantic_id(model, data['x'], data['edge_index'])
+
+        if epoch % args.display_step == 0:
+            print(
+                f"Epoch [{epoch + 1:0>3d}]  "
+                f"train loss: {train_loss.item():.4f}  "
+                f"train acc: {result['train_acc'] * 100:.2f}%  "
+                f"val acc: {result['valid_acc'] * 100:.2f}%  "
+                f"test acc: {result['test_acc'] * 100:.2f}%  "
+                f"best val: {best_valid * 100:.2f}%  "
+                f"best test: {best_test * 100:.2f}%"
+            )
+
+    if args.save_semantic_id:
+        semantic_id_path = args.semantic_id_path or f'semantic_ID_{args.dataset}.npz'
+        if best_semantic_id is None:
+            save_semantic_id(model, data['x'], data['edge_index'], semantic_id_path)
+        else:
+            np.savez(semantic_id_path, best_semantic_id)
+            print(f'saved semantic id to {semantic_id_path} (best-valid checkpoint)')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='NodeID Stage-1 (GNN + VQ) in GammaGL style')
+    parser.add_argument('--dataset', type=str, default='cora')
+    parser.add_argument('--dataset_path', type=str, default='')
+    parser.add_argument('--gpu', type=int, default=0)
+    parser.add_argument('--seed', type=int, default=42)
+    parser.add_argument('--split_seed', type=int, default=-1)
+    parser.add_argument('--train_seed', type=int, default=-1)
+    parser.add_argument('--rand_split', action='store_true')
+    parser.add_argument('--train_prop', type=float, default=0.6)
+    parser.add_argument('--valid_prop', type=float, default=0.2)
+
+    parser.add_argument('--n_epoch', type=int, default=1000)
+    parser.add_argument('--display_step', type=int, default=50)
+    parser.add_argument('--lr', type=float, default=0.001)
+    parser.add_argument('--l2_coef', type=float, default=5e-4)
+
+    parser.add_argument('--method', type=str, default='gat', choices=['gat', 'gcn'])
+    parser.add_argument('--hidden_channels', type=int, default=256)
+    parser.add_argument('--local_layers', type=int, default=7)
+    parser.add_argument('--num_heads', type=int, default=1)
+    parser.add_argument('--in_dropout', type=float, default=0.0)
+    parser.add_argument('--dropout', type=float, default=0.5)
+    parser.add_argument('--pre_ln', action='store_true')
+
+    parser.add_argument('--kmeans', type=int, default=1)
+    parser.add_argument('--num_codes', type=int, default=16)
+    parser.add_argument('--commit_weight', type=float, default=1.0)
+    parser.add_argument('--save_semantic_id', action='store_true')
+    parser.add_argument('--semantic_id_path', type=str, default='')
+
+    args = parser.parse_args()
+
+    if args.gpu >= 0:
+        tlx.set_device('GPU', args.gpu)
+    else:
+        tlx.set_device('CPU')
+
+    main(args)

--- a/examples/nodeid/readme.md
+++ b/examples/nodeid/readme.md
@@ -1,0 +1,94 @@
+Node Identifiers: Compact, Discrete Representations for Efficient Graph Learning
+====================================
+
+This example reproduces the two-stage NodeID pipeline in GammaGL.
+
+- Paper link: [https://arxiv.org/pdf/2405.16435](https://arxiv.org/pdf/2405.16435)
+- Author's code repo: [https://github.com/LUOyk1999/NodeID](https://github.com/LUOyk1999/NodeID)
+
+- Stage 1 (`nodeid_trainer.py`): GNN + VQ to generate semantic IDs.
+- Stage 2 (`nodeid_id_mlp.py`): ID-MLP on exported semantic IDs.
+
+How to run
+----------
+
+```bash
+cd examples/nodeid
+TL_BACKEND=torch python nodeid_trainer.py --dataset cora --method gcn --n_epoch 1000 --gpu 0
+```
+
+Two-stage pipeline
+------------------
+
+Run Stage 1 and export semantic IDs:
+
+```bash
+TL_BACKEND=torch python nodeid_trainer.py --dataset cora --method gcn --n_epoch 1000 --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --save_semantic_id --semantic_id_path semantic_ID_cora.npz
+```
+
+Run Stage 2 ID-MLP:
+
+```bash
+TL_BACKEND=torch python nodeid_id_mlp.py --dataset cora --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --semantic_id_path semantic_ID_cora.npz \
+  --num_layers 2 --hidden_channels 256 --dropout 0.0 \
+  --lr 0.001 --l2_coef 5e-4 --n_epoch 1000
+```
+
+Results
+-------
+
+All results below use:
+
+- `--rand_split --train_prop 0.6 --valid_prop 0.2 --seed 123`
+- `1000` training epochs
+
+| Dataset | Method | Original (Highest Valid / Highest Test, %) | Reproduction (Best Valid / Best Test, %) |
+| :-----: | :----: | :----------------------------------------: | :---------------------------------------: |
+| Cora | GCN | 88.72 / 88.21 | 88.13 ± 0.40 / 87.55 ± 0.50 |
+| Citeseer | GCN | 74.44 / 76.88 | 75.31 ± 0.89 / 75.71 ± 1.54 |
+| Cora | ID-MLP (from GCN semantic ID) | 87.06 / 86.92 | 86.25 ± 0.98 / 84.53 ± 0.49 |
+| Citeseer | ID-MLP (from GCN semantic ID) | 71.88 / 74.32 | 72.03 ± 2.01 / 72.73 ± 2.32 |
+| Cora | ID-MLP (from GAT semantic ID) | 87.25 / 85.64 | 87.14 ± 0.56 / 86.23 ± 1.12 |
+| Citeseer | ID-MLP (from GAT semantic ID) | 73.53 / 73.72 | 70.41 ± 1.22 / 70.57 ± 0.84 |
+| Cora | GAT | 88.17 / 88.77 | 88.32 ± 0.15 / 86.92 ± 0.89 |
+| Citeseer | GAT | 75.04 / 77.03 | 73.14 ± 0.35 / 72.85 ± 1.33 |
+
+Notes
+-----
+
+- `Original` values are from `NodeID-main/SL/Node_Classification` logs.
+- `Reproduction` values are shown as `mean ± std` over fixed-split 5 runs (`split_seed=123`, `train_seed=123..127`).
+- Raw per-run values and summary are saved in `repro_stats_fixedsplit_5runs.json`.
+- Stage-1 semantic IDs are exported from the best-validation checkpoint.
+- GCN/GAT and their ID-MLP rows now share the same fixed-split 5-run protocol.
+- Current table is based on reruns dated `2026-03-23`.
+- Default examples use GPU (`--gpu 0`); change to `--gpu 1..N` for another device.
+
+Reproduction commands (main settings)
+-------------------------------------
+
+```bash
+# Cora / GCN
+TL_BACKEND=torch python nodeid_trainer.py --dataset cora --method gcn --n_epoch 1000 --display_step 50 --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --lr 0.001 --local_layers 5 --hidden_channels 256 --l2_coef 5e-4 --dropout 0.0 --num_codes 6
+
+# Cora / GAT
+TL_BACKEND=torch python nodeid_trainer.py --dataset cora --method gat --n_epoch 1000 --display_step 50 --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --lr 0.005 --local_layers 4 --hidden_channels 256 --l2_coef 5e-4 --dropout 0.0 --num_codes 8
+
+# Citeseer / GCN
+TL_BACKEND=torch python nodeid_trainer.py --dataset citeseer --method gcn --n_epoch 1000 --display_step 50 --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --lr 0.005 --local_layers 5 --hidden_channels 64 --l2_coef 0.01 --dropout 0.0 --num_codes 16
+
+# Citeseer / GAT
+TL_BACKEND=torch python nodeid_trainer.py --dataset citeseer --method gat --n_epoch 1000 --display_step 50 --gpu 0 \
+  --rand_split --seed 123 --train_prop 0.6 --valid_prop 0.2 \
+  --lr 0.005 --local_layers 4 --hidden_channels 64 --l2_coef 0.01 --dropout 0.5 --num_codes 8
+```

--- a/gammagl/models/__init__.py
+++ b/gammagl/models/__init__.py
@@ -66,6 +66,7 @@ from .rohehan import RoheHAN
 from .gcil import GCILModel, LogReg 
 from .sgformer import SGFormerModel
 from .adagad import PreModel, ReModel
+from .nodeid import NodeIDGNN
 
 __all__ = [
     'HeCo',
@@ -141,6 +142,7 @@ __all__ = [
     'sgformer',
     'PreModel',
     'ReModel'
+    , 'NodeIDGNN'
 ]
 
 classes = __all__

--- a/gammagl/models/nodeid.py
+++ b/gammagl/models/nodeid.py
@@ -1,0 +1,256 @@
+import tensorlayerx as tlx
+import tensorlayerx.nn as nn
+import numpy as np
+
+from gammagl.layers.conv import GATConv, GCNConv
+
+
+def l2norm(tensor):
+    return tlx.l2_normalize(tensor, axis=-1)
+
+
+def one_hot(indices, depth):
+    return tlx.ops.OneHot(depth=depth)(indices)
+
+
+class VectorQuantize(tlx.nn.Module):
+    def __init__(
+        self,
+        dim,
+        codebook_size,
+        commitment_weight=0.25,
+        decay=0.8,
+        eps=1e-5,
+        threshold_ema_dead_code=2,
+    ):
+        super().__init__()
+        self.dim = dim
+        self.codebook_size = codebook_size
+        self.commitment_weight = commitment_weight
+        self.decay = decay
+        self.eps = eps
+        self.threshold_ema_dead_code = threshold_ema_dead_code
+
+        init_weight = tlx.initializers.XavierUniform()
+        self.embed = tlx.cast(init_weight((codebook_size, dim)), tlx.float32)
+        self.embed_avg = np.array(tlx.convert_to_numpy(self.embed), copy=True)
+        self.cluster_size = np.zeros((codebook_size,), dtype=np.float32)
+
+    def _ema_update_codebook(self, flat_x, embed_onehot):
+        flat_x_np = tlx.convert_to_numpy(flat_x).astype(np.float32)
+        onehot_np = tlx.convert_to_numpy(embed_onehot).astype(np.float32)
+
+        counts = onehot_np.sum(axis=0)
+        embed_sum = onehot_np.T @ flat_x_np
+
+        self.cluster_size = self.cluster_size * self.decay + (1.0 - self.decay) * counts
+        self.embed_avg = self.embed_avg * self.decay + (1.0 - self.decay) * embed_sum
+
+        cluster_size_sum = float(self.cluster_size.sum())
+        if cluster_size_sum > 0:
+            cluster_size = ((self.cluster_size + self.eps) /
+                            (cluster_size_sum + self.codebook_size * self.eps)) * cluster_size_sum
+        else:
+            cluster_size = np.ones_like(self.cluster_size, dtype=np.float32)
+
+        new_embed = self.embed_avg / np.expand_dims(np.maximum(cluster_size, self.eps), axis=-1)
+
+        dead_mask = self.cluster_size < self.threshold_ema_dead_code
+        dead_count = int(dead_mask.sum())
+        if dead_count > 0:
+            replace = flat_x_np.shape[0] < dead_count
+            sample_idx = np.random.choice(flat_x_np.shape[0], dead_count, replace=replace)
+            new_embed[dead_mask] = flat_x_np[sample_idx]
+            self.embed_avg[dead_mask] = new_embed[dead_mask]
+            self.cluster_size[dead_mask] = self.threshold_ema_dead_code
+
+        self.embed = tlx.convert_to_tensor(new_embed.astype(np.float32), dtype=tlx.float32)
+
+    def forward(self, x):
+        only_one = len(tlx.get_tensor_shape(x)) == 2
+        if only_one:
+            x = tlx.expand_dims(x, axis=1)
+
+        shape = tlx.get_tensor_shape(x)
+        flat_x = tlx.reshape(x, (-1, self.dim))
+
+        flat_x_norm = l2norm(flat_x)
+        embed_norm = l2norm(self.embed)
+        sim = tlx.matmul(flat_x_norm, tlx.transpose(embed_norm))
+
+        embed_ind = tlx.argmax(sim, axis=-1)
+        embed_onehot = tlx.cast(one_hot(embed_ind, self.codebook_size), tlx.float32)
+        quantize = tlx.matmul(embed_onehot, self.embed)
+        quantize = tlx.reshape(quantize, shape)
+
+        if self.is_train:
+            self._ema_update_codebook(flat_x, embed_onehot)
+
+        if self.is_train:
+            quantize = x + tlx.detach(quantize - x)
+
+        commit_loss = tlx.reduce_mean(tlx.square(tlx.detach(quantize) - x))
+        loss = commit_loss * self.commitment_weight
+
+        embed_ind = tlx.reshape(embed_ind, (shape[0], shape[1]))
+
+        if only_one:
+            quantize = tlx.squeeze(quantize, axis=1)
+            embed_ind = tlx.squeeze(embed_ind, axis=1)
+
+        return quantize, embed_ind, loss
+
+
+class ResidualVectorQuant(tlx.nn.Module):
+    def __init__(
+        self,
+        dim,
+        codebook_size,
+        num_res_layers=3,
+        commitment_weight=0.25,
+        decay=0.8,
+        eps=1e-5,
+        threshold_ema_dead_code=2,
+    ):
+        super().__init__()
+        self.vq_layers = nn.ModuleList(
+            [
+                VectorQuantize(
+                    dim=dim,
+                    codebook_size=codebook_size,
+                    commitment_weight=commitment_weight,
+                    decay=decay,
+                    eps=eps,
+                    threshold_ema_dead_code=threshold_ema_dead_code,
+                )
+                for _ in range(num_res_layers)
+            ]
+        )
+
+    def forward(self, x):
+        quantized_outputs = []
+        total_loss = 0
+        embed_indices = []
+
+        residual = x
+        for vq_layer in self.vq_layers:
+            quantized, embed_ind, layer_loss = vq_layer(residual)
+            total_loss = total_loss + layer_loss
+            embed_indices.append(embed_ind)
+            quantized_outputs.append(quantized)
+            residual = residual - quantized
+
+        output = quantized_outputs[0]
+        for i in range(1, len(quantized_outputs)):
+            output = output + quantized_outputs[i]
+
+        return output, embed_indices, total_loss
+
+
+class NodeIDGNN(tlx.nn.Module):
+    def __init__(
+        self,
+        in_channels,
+        hidden_channels,
+        out_channels,
+        local_layers=3,
+        in_dropout=0.0,
+        dropout=0.5,
+        heads=1,
+        pre_ln=False,
+        kmeans=1,
+        num_codes=16,
+        gnn='gat',
+        vq_decay=0.8,
+        vq_eps=1e-5,
+        vq_dead_code_threshold=2,
+    ):
+        super().__init__()
+        self.in_drop = nn.Dropout(in_dropout)
+        self.dropout = nn.Dropout(dropout)
+        self.pre_ln = pre_ln
+        self.kmeans = kmeans
+        self.hidden_dim = hidden_channels * heads
+        self.gnn = gnn
+
+        self.vqs = nn.ModuleList()
+        self.local_convs = nn.ModuleList()
+        self.lins = nn.ModuleList()
+        if self.pre_ln:
+            self.pre_lns = nn.ModuleList()
+
+        for _ in range(local_layers):
+            if gnn == 'gat':
+                self.local_convs.append(
+                    GATConv(
+                        in_channels=self.hidden_dim,
+                        out_channels=hidden_channels,
+                        heads=heads,
+                        concat=True,
+                        dropout_rate=dropout,
+                        add_bias=False,
+                    )
+                )
+            else:
+                self.local_convs.append(
+                    GCNConv(
+                        in_channels=self.hidden_dim,
+                        out_channels=self.hidden_dim,
+                        norm='both',
+                    )
+                )
+
+            self.vqs.append(
+                ResidualVectorQuant(
+                    dim=self.hidden_dim,
+                    codebook_size=num_codes,
+                    num_res_layers=3,
+                    commitment_weight=0.25,
+                    decay=vq_decay,
+                    eps=vq_eps,
+                    threshold_ema_dead_code=vq_dead_code_threshold,
+                )
+            )
+            self.lins.append(nn.Linear(in_features=self.hidden_dim, out_features=self.hidden_dim))
+            if self.pre_ln:
+                self.pre_lns.append(nn.LayerNorm(self.hidden_dim))
+
+        self.lin_in = nn.Linear(in_features=in_channels, out_features=self.hidden_dim)
+        self.linear_gnn = nn.Linear(in_features=self.hidden_dim, out_features=local_layers * 3)
+        self.pred_local = nn.Linear(in_features=self.hidden_dim, out_features=out_channels)
+        self.relu = tlx.ReLU()
+
+    def forward(self, x, edge_index):
+        x = self.in_drop(x)
+        x = self.lin_in(x)
+        x = self.dropout(x)
+
+        id_list = []
+        total_commit_loss = 0
+        x_local = 0
+
+        num_nodes = tlx.get_tensor_shape(x)[0]
+
+        for layer_id, (local_conv, vq) in enumerate(zip(self.local_convs, self.vqs)):
+            if self.pre_ln:
+                x = self.pre_lns[layer_id](x)
+
+            if self.gnn == 'gat':
+                conv_out = local_conv(x, edge_index, num_nodes=num_nodes)
+            else:
+                conv_out = local_conv(x, edge_index, edge_weight=None, num_nodes=num_nodes)
+
+            x = conv_out + self.lins[layer_id](x)
+            x = self.relu(x)
+            x = self.dropout(x)
+            x_local = x_local + x
+
+            quantized, code_indices, commit_loss = vq(x)
+            id_list.append(tlx.stack(code_indices, axis=1))
+            total_commit_loss = total_commit_loss + commit_loss
+
+        id_list_concat = tlx.concat(id_list, axis=1)
+        gnn_id = self.linear_gnn(x_local)
+        logits = self.pred_local(x_local)
+
+        return logits, total_commit_loss, id_list_concat, gnn_id


### PR DESCRIPTION
## Summary
- Add NodeID model implementation to GammaGL models.
- Add two-stage NodeID example scripts for node classification.
- Add NodeID example README with run instructions and reproduction results.

## Motivation
- Reproduce the NodeID pipeline in GammaGL style.
- Provide a complete stage-1 (GNN+VQ) + stage-2 (ID-MLP) workflow for users.

## Changes
- Add model module and export registration for NodeID.
- Add stage-1 trainer for semantic ID generation.
- Add stage-2 ID-MLP trainer that consumes exported semantic IDs.
- Add example documentation and runnable commands.

## Validation
- Ran end-to-end flow with Cora/Citeseer settings used in the example.
- Confirmed scripts execute successfully in current environment and produce expected outputs.
